### PR TITLE
Rename OCP cluster: from mas suffix to apicurio suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 - [Cluster and Namespace](#cluster-and-namespace)
 - [This Repository](#this-repository)
   - [Manifests](#manifests)
-  - [Local Verification](#local-verification)
   - [Continuous Deployment](#continuous-deployment)
 - [RDS Database](#rds-database)
   - [RDS Specifics](#rds-specifics)
@@ -24,78 +23,70 @@
 
 # 3scale DEV
 The 3scale DEV environment is an ArgoCD controlled OpenShift cluster provided by the 3scale
-SRE team.  We have been granted an `apicurio` namespace within this cluster so that we can 
+SRE team.  We have been granted an `apicurio` namespace within this cluster so that we can
 deploy DEV versions of our Apicurio applications.
 
 # Useful links
 
 ## Infrastructure
-  
-- [OpenShift Console](https://console-openshift-console.apps.dev-eng-ocp4-mas.dev.3sca.net/)
 
-- [ArgoCd Console](https://gitops.apps.dev-eng-ocp4-mas.dev.3sca.net/applications)
+- [OpenShift Console](https://console-openshift-console.apps.dev-eng-hcp-apicurio.dev.3sca.net/)
 
-- [Vault](https://vault.apps.dev-eng-ocp4-mas.dev.3sca.net/)
+- [ArgoCd Console](https://gitops.apps.dev-eng-hcp-apicurio.dev.3sca.net/applications)
+
+- [Vault](https://vault.apps.dev-eng-hcp-apicurio.dev.3sca.net/)
 
 ## Applications
 
 - [Keycloak](https://sso.dev.apicur.io/)
 
 - [Backstage](https://backstage.dev.apicur.io/)
-  
+
 - [Apicurio Registry](https://registry.dev.apicur.io/)
 
 - [Apicurio Studio](https://studio.dev.apicur.io/)
 
 # Cluster and Namespace
 
-The projects are presently deployed on the 3scale OpenShift Cluster and overseen by the 3Scale 
-platform's SRE team. If you encounter any challenges or have inquiries regarding the infrastructure, 
-there's the [#list-3scale-sre-mas](https://redhat-internal.slack.com/archives/C0586GTTXH9) Slack channel 
+The projects are presently deployed on the 3scale OpenShift Cluster and overseen by the 3Scale
+platform's SRE team. If you encounter any challenges or have inquiries regarding the infrastructure,
+there's the [#list-3scale-sre-apicurio](https://redhat-internal.slack.com/archives/C0586GTTXH9) Slack channel
 available for you to get in touch with them.
 
-We currently have a single namespace allocated for our use, namely `apicurio` with the resource 
-quotas listed below.
+We currently have a single namespace allocated for our use, namely `apicurio`.
 
-``` 
-requests.cpu: '4'
-requests.memory: 10Gi
-services.loadbalancers: '0'
-```
+> Please note that this is a development cluster equipped with only two OpenShift Container Platform (OCP) worker nodes. Each node has 4 CPUs and 15GB of memory available, serving the needs of OCP, 3Scale and Apicurio components. If additional capacity is required, we can consider a **MODEST INCREASE**  only after optimizing resource requests to match actual usage. However, any adjustments will be made conservatively.
 
-
-> Please note that this is a development cluster equipped with only three OpenShift Container Platform (OCP) worker nodes. Each node has 4 CPUs and 15GB of memory available, serving the needs of OCP, 3Scale and Apicurio components. If additional capacity is required, we can consider a **MODEST INCREASE** in the quota only after optimizing resource requests to match actual usage. However, any adjustments will be made conservatively.
-
-For more details on the cluster and available services, [click here](https://github.com/3scale/platform/blob/master/docs/projects/engineering/dev-ocp-mas.md). 
+For more details on the cluster and available services, [click here](https://github.com/3scale/platform/blob/master/docs/projects/engineering/dev-eng-hcp-apicurio.md).
 
 
 # This Repository
 
-This repository holds the manifest files that are used for deploying the apicurio projects on the 3scale cluster. 
+This repository holds the manifest files that are used for deploying the apicurio projects on the 3scale cluster.
 
-The project uses [kustomize](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/) and 
-[Argo CD](https://argo-cd.readthedocs.io/en/stable/) to enable GitOps and continuous deployments. Hence, any 
+The project uses [kustomize](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/) and
+[Argo CD](https://argo-cd.readthedocs.io/en/stable/) to enable GitOps and continuous deployments. Hence, any
 changes made to the manifest files will automatically be applied to the project deployments.
 
 ## Manifests
 The kubernetes/OpenShift manifest files for each project are organized under the `applications` folder.
 
-Each subfolder under the `applications` folder is an application monitored and deployed by ArgoCD.  The 
-ArgoCD applications are configured in the [3scale-platform git](https://github.com/3scale/platform/tree/master/manifests/apps/openshift-gitops/overlays/dev-eng-mas/apps) repository.
+Each subfolder under the `applications` folder is an application monitored and deployed by ArgoCD.  The
+ArgoCD applications are configured in the [3scale-platform git](https://github.com/3scale/platform/tree/master/manifests/bases/rhacm-policies/apicurio/openshift-gitops/apps) repository.
 
 
 ## Continuous Deployment
 
 This project leverages Argo CD for seamless and automated continuous deployment. Any modifications made to
-the manifest files trigger an automatic deployment through these [Argo CD applications](https://gitops.apps.dev-eng-ocp4-mas.dev.3sca.net/applications?showFavorites=false&proj=&sync=&autoSync=&health=&namespace=&cluster=&labels=).
+the manifest files trigger an automatic deployment through these [Argo CD applications](https://gitops.apps.dev-eng-hcp-apicurio.dev.3sca.net/applications?showFavorites=false&proj=&sync=&autoSync=&health=&namespace=&cluster=&labels=).
 
-The application is set to synchronize every 5 minutes for regular updates. However, you also have the option 
-to manually initiate a synchronization by clicking on the **refresh** button. This ensures that changes are 
+The application is set to synchronize every 5 minutes for regular updates. However, you also have the option
+to manually initiate a synchronization by clicking on the **refresh** button. This ensures that changes are
 promptly reflected in the deployed environment.
 
-**TODO:** As of now, our permissions are limited to read-only access for the Argo applications. Any attempts 
-to execute actions are met with denial, stemming from permission constraints. To address this, we could have 
-the assignment of the following admin role to our [AppProject](https://github.com/3scale/platform/blob/master/manifests/apps/openshift-gitops/overlays/dev-eng-mas/apps/apicurio-registry/appproject.yaml).
+**TODO:** As of now, our permissions are limited to read-only access for the Argo applications. Any attempts
+to execute actions are met with denial, stemming from permission constraints. To address this, we could have
+the assignment of the following admin role to our [AppProject](https://github.com/3scale/platform/blob/master/manifests/bases/rhacm-policies/apicurio/openshift-gitops/apps/apicurio-registry/appproject.yaml).
 
 ```
 roles:
@@ -110,22 +101,22 @@ roles:
         - p, proj:apicurio-registry:project-admin, applications, override, apicurio-registry/*, allow
         - p, proj:apicurio-registry:project-admin, applications, action/*, apicurio-registry/*, allow
       groups:
-        - rhaf-dev
+        - apicurio
 ```
 
-> Note: The ArgoCD deployments are configured and managed by the SRE team in the 3scale platform repository [here](https://github.com/3scale/platform/tree/master/manifests/apps/openshift-gitops)
+> Note: The ArgoCD deployments are configured and managed by the SRE team in the 3scale platform repository [here](https://github.com/3scale/platform/tree/master/manifests/bases/openshift-gitops)
 
 
 # RDS Database
-The Apicurio 3scale cluster setup leverages a private Amazon RDS (Relational Database Service) instance 
+The Apicurio 3scale cluster setup leverages a private Amazon RDS (Relational Database Service) instance
 as its primary data storage solution.
 
 ## RDS Specifics
 
 - DB Type: PostgreSQL
-- DB engine version: 15.4
+- DB engine version: 15.7
 - Instance Type: db.t4g.small (2 vCPU and 2GB memory)
-- Instance Storage: 30 GB
+- Instance Storage: 32 GB
 
 >  Being a development AWS RDS instance, features typically needed for production workloads like MultiAZ, detailed monitoring, long backup retention, etc are not enabled.
 
@@ -134,32 +125,32 @@ as its primary data storage solution.
 
 Connections string (master user, master password, RDS host...) can be found at Vault path:
 
-https://vault.apps.dev-eng-ocp4-mas.dev.3sca.net/ui/vault/secrets/secret/show/kubernetes/dev-eng-mas/rhaf-apicurio-registry/dev-eng-mas-apicurio-rds-pgsql-master-credentials
+https://vault.apps.dev-eng-hcp-apicurio.dev.3sca.net/ui/vault/secrets/secret/show/kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-master-credentials
 
 
 ## How you should use the master credentials?
 
-The master username and password should be used exclusively for the creation of individual user accounts, 
-associated databases, and the granting of relevant privileges. It is imperative not to utilize them directly 
+The master username and password should be used exclusively for the creation of individual user accounts,
+associated databases, and the granting of relevant privileges. It is imperative not to utilize them directly
 within your application.
 
-This approach ensures that each application is associated with a dedicated user account, limited to accessing 
-a specific database. Consequently, in the unfortunate event of an application compromise, any potential attacker 
+This approach ensures that each application is associated with a dedicated user account, limited to accessing
+a specific database. Consequently, in the unfortunate event of an application compromise, any potential attacker
 would only gain access to the specific database associated with that particular application.
 
 ## How to create new user accounts and DB?
 
-To connect to the RDS database, a PostgreSQL client is required. However, you won't be able to connect to the 
-RDS instance directly from your laptop, because the RDS is confined to the cluster network's access due to 
+To connect to the RDS database, a PostgreSQL client is required. However, you won't be able to connect to the
+RDS instance directly from your laptop, because the RDS is confined to the cluster network's access due to
 security measures in place.
 
-As a solution, a PostgreSQL client (pg-client) has been provisioned within the cluster. You can utilize it to 
+As a solution, a PostgreSQL client (pg-client) has been provisioned within the cluster. You can utilize it to
 establish a connection with the database by following the steps below:
 
 1. **Login to the openshift cluster.**
 2. **Exec into the pg-client pod running in the cluster.**
     ```
-    oc exec -it pg-client -n rhaf-apicurio -- /bin/bash
+    oc exec -it pg-client -n apicurio -- /bin/bash
     ```
 3. **Connect to the RDS**
     ```
@@ -189,10 +180,10 @@ PGPASSWORD='<password>' psql -h <hostname> -U apicurio -d apicurio
 
 We employ HashiCorp Vault as a trusted solution for securely managing and storing sensitive information, such
 as secrets, credentials, and other confidential data. Vault ensures the highest level of security by providing
-a centralized platform for secret management, encryption, and access control. By leveraging Vault's robust 
-features and integrations, we can securely store, retrieve, and distribute secrets to our applications and 
-services while maintaining strict access controls and audit trails. This approach not only enhances the 
-security posture of our deployments but also streamlines the management of secrets, making it an essential 
+a centralized platform for secret management, encryption, and access control. By leveraging Vault's robust
+features and integrations, we can securely store, retrieve, and distribute secrets to our applications and
+services while maintaining strict access controls and audit trails. This approach not only enhances the
+security posture of our deployments but also streamlines the management of secrets, making it an essential
 component of our infrastructure.
 
 ## Vault Access
@@ -201,26 +192,26 @@ component of our infrastructure.
    - Within your GitHub account, access your "Personal settings" by clicking on your profile picture in the upper right corner of the screen and then selecting "settings".
 
    - Proceed to "Developer settings", followed by "Personal access tokens", and click on "Generate new token". Make sure to grant at least the `read:org` permission.
-2. Visit the [Vault Application](https://vault.apps.dev-eng-ocp4-mas.dev.3sca.net/ui/)
+2. Visit the [Vault Application](https://vault.apps.dev-eng-hcp-apicurio.dev.3sca.net/ui/)
 3. Authenticate using your GitHub Token.
 
 ## Adding Secrets
 
-1. Navigate to `secrets > secret > kubernetes > dev-eng-mas > apicurio`
+1. Navigate to `secrets > secret > kubernetes > dev-eng-apicurio > apicurio`
 2. From the WebApplication Secrets page, click Add new secret.
 3. Enter secretname in the `Name`` field and secret-value in the Value field, and click Save.
 
 
 ## Creating External Secrets
 
-External Secrets is a Kubernetes extension that enables the integration of external secret management 
-systems, such as HashiCorp Vault, with your Kubernetes clusters. By leveraging External Secrets, you 
-can centralize the management of secrets in established external systems while benefiting from Kubernetes' 
+External Secrets is a Kubernetes extension that enables the integration of external secret management
+systems, such as HashiCorp Vault, with your Kubernetes clusters. By leveraging External Secrets, you
+can centralize the management of secrets in established external systems while benefiting from Kubernetes'
 native secret controller capabilities.
 
-After successfully adding the credentials within the vault, you can proceed to define the ExternalSecret 
+After successfully adding the credentials within the vault, you can proceed to define the ExternalSecret
 Custom Resource. Below is an illustrative YAML example pertaining to the secret named
-dev-eng-mas-apicurio-rds-pgsql-apicurio-credentials, which has been incorporated into the vault.
+dev-eng-apicurio-rds-pgsql-apicurio-credentials, which has been incorporated into the vault.
 
 ```
 apiVersion: external-secrets.io/v1beta1
@@ -232,28 +223,28 @@ spec:
     name: rds-apicurio-credentials
   secretStoreRef:
     kind: ClusterSecretStore
-    name: vault-mas  
+    name: vault-apicurio
   refreshInterval: 1m0s
   data:
     - secretKey: database
       remoteRef:
-        key: kubernetes/dev-eng-mas/apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-credentials
         property: database
     - secretKey: host
       remoteRef:
-        key: kubernetes/dev-eng-mas/apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-credentials
         property: host
     - secretKey: port
       remoteRef:
-        key: kubernetes/dev-eng-mas/apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-credentials
         property: port
     - secretKey: user
       remoteRef:
-        key: kubernetes/dev-eng-mas/apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-credentials
         property: user
     - secretKey: password
       remoteRef:
-        key: kubernetes/dev-eng-mas/apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-credentials
         property: password
 ```
 

--- a/applications/apicurio-registry/api-controller-flow/cdc/connector/source-postgres-connector.yaml
+++ b/applications/apicurio-registry/api-controller-flow/cdc/connector/source-postgres-connector.yaml
@@ -1,6 +1,8 @@
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaConnector
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: postgres-connector0
   labels:
     strimzi.io/cluster: kafka-connect-cluster

--- a/applications/apicurio-registry/api-controller-flow/cdc/connector/source-postgres-connector.yaml
+++ b/applications/apicurio-registry/api-controller-flow/cdc/connector/source-postgres-connector.yaml
@@ -17,8 +17,8 @@ spec:
     transforms: "outbox"
     transforms.outbox.type: "io.debezium.transforms.outbox.EventRouter"
     connector.class": "io.debezium.connector.postgresql.PostgresConnector"
-    database.hostname: ${secrets:rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-registry-credentials:host}
-    database.port: ${secrets:rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-registry-credentials:port}
-    database.user: ${secrets:rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-registry-credentials:user}
-    database.password: ${secrets:rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-registry-credentials:password}
-    database.dbname: ${secrets:rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-registry-credentials:database}
+    database.hostname: ${secrets:apicurio/dev-eng-apicurio-rds-pgsql-apicurio-registry-credentials:host}
+    database.port: ${secrets:apicurio/dev-eng-apicurio-rds-pgsql-apicurio-registry-credentials:port}
+    database.user: ${secrets:apicurio/dev-eng-apicurio-rds-pgsql-apicurio-registry-credentials:user}
+    database.password: ${secrets:apicurio/dev-eng-apicurio-rds-pgsql-apicurio-registry-credentials:password}
+    database.dbname: ${secrets:apicurio/dev-eng-apicurio-rds-pgsql-apicurio-registry-credentials:database}

--- a/applications/apicurio-registry/client-application/cdc/connectors/rds-external-secrets.yaml
+++ b/applications/apicurio-registry/client-application/cdc/connectors/rds-external-secrets.yaml
@@ -7,26 +7,26 @@ spec:
     name: rds-apicurio-registry-client-application-credentials
   secretStoreRef:
     kind: ClusterSecretStore
-    name: vault-mas
+    name: vault-apicurio
   refreshInterval: 1m0s
   data:
     - secretKey: database
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-registry-client-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-registry-client-credentials
         property: database
     - secretKey: host
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-registry-client-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-registry-client-credentials
         property: host
     - secretKey: port
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-registry-client-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-registry-client-credentials
         property: port
     - secretKey: user
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-registry-client-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-registry-client-credentials
         property: user
     - secretKey: password
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-registry-client-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-registry-client-credentials
         property: password

--- a/applications/apicurio-registry/client-application/cdc/connectors/source-postgres-connector.yaml
+++ b/applications/apicurio-registry/client-application/cdc/connectors/source-postgres-connector.yaml
@@ -1,6 +1,8 @@
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaConnector
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: postgres-connector0
   labels:
     strimzi.io/cluster: kafka-connect-cluster

--- a/applications/apicurio-registry/client-application/cdc/connectors/source-postgres-connector.yaml
+++ b/applications/apicurio-registry/client-application/cdc/connectors/source-postgres-connector.yaml
@@ -8,11 +8,11 @@ spec:
   class: io.debezium.connector.postgresql.PostgresConnector
   tasksMax: 1
   config:
-    database.hostname: ${secrets:rhaf-apicurio/rds-apicurio-registry-client-application-credentials:host}
-    database.port: ${secrets:rhaf-apicurio/rds-apicurio-registry-client-application-credentials:port}
-    database.user: ${secrets:rhaf-apicurio/rds-apicurio-registry-client-application-credentials:user}
-    database.password: ${secrets:rhaf-apicurio/rds-apicurio-registry-client-application-credentials:password}
-    database.dbname: ${secrets:rhaf-apicurio/rds-apicurio-registry-client-application-credentials:database}
+    database.hostname: ${secrets:apicurio/rds-apicurio-registry-client-application-credentials:host}
+    database.port: ${secrets:apicurio/rds-apicurio-registry-client-application-credentials:port}
+    database.user: ${secrets:apicurio/rds-apicurio-registry-client-application-credentials:user}
+    database.password: ${secrets:apicurio/rds-apicurio-registry-client-application-credentials:password}
+    database.dbname: ${secrets:apicurio/rds-apicurio-registry-client-application-credentials:database}
     heartbeat.interval.ms: "1000"
     plugin.name: "pgoutput"
     topic.prefix: "server1"
@@ -21,11 +21,11 @@ spec:
     key.converter.apicurio.registry.url: "https://registry-api.dev.apicur.io/apis/registry/v3"
     key.converter.apicurio.registry.auto-register: "true"
     key.converter.apicurio.registry.find-latest: "true"
-    key.converter.apicurio.registry.auth.client.id: ${secrets:rhaf-apicurio/probe-application-credentials:client-id}
-    key.converter.apicurio.registry.auth.client.secret: ${secrets:rhaf-apicurio/probe-application-credentials:client-secret}
+    key.converter.apicurio.registry.auth.client.id: ${secrets:apicurio/probe-application-credentials:client-id}
+    key.converter.apicurio.registry.auth.client.secret: ${secrets:apicurio/probe-application-credentials:client-secret}
     key.converter.apicurio.registry.auth.service.token.endpoint: "https://sso.dev.apicur.io/realms/apicurio/protocol/openid-connect/token"
-    value.converter.apicurio.registry.auth.client.id: ${secrets:rhaf-apicurio/probe-application-credentials:client-id}
-    value.converter.apicurio.registry.auth.client.secret: ${secrets:rhaf-apicurio/probe-application-credentials:client-secret}
+    value.converter.apicurio.registry.auth.client.id: ${secrets:apicurio/probe-application-credentials:client-id}
+    value.converter.apicurio.registry.auth.client.secret: ${secrets:apicurio/probe-application-credentials:client-secret}
     value.converter.apicurio.registry.auth.service.token.endpoint: "https://sso.dev.apicur.io/realms/apicurio/protocol/openid-connect/token"
     value.converter: "io.apicurio.registry.utils.converter.AvroConverter"
     value.converter.apicurio.registry.url: "https://registry-api.dev.apicur.io/apis/registry/v3"

--- a/applications/apicurio-registry/client-application/cdc/kafka/connect-cluster.yaml
+++ b/applications/apicurio-registry/client-application/cdc/kafka/connect-cluster.yaml
@@ -31,7 +31,7 @@ spec:
   build:
     output:
       type: docker
-      image: image-registry.openshift-image-registry.svc:5000/rhaf-apicurio/debezium-connect:latest
+      image: image-registry.openshift-image-registry.svc:5000/apicurio/debezium-connect:latest
     plugins:
       - name: debezium-connector-postgres
         artifacts:
@@ -58,7 +58,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: kafka-connect-cluster-connect
-    namespace: rhaf-apicurio
+    namespace: apicurio
 roleRef:
   kind: Role
   name: connector-configuration-role

--- a/applications/apicurio-registry/client-application/cdc/kafka/connect-cluster.yaml
+++ b/applications/apicurio-registry/client-application/cdc/kafka/connect-cluster.yaml
@@ -5,6 +5,7 @@ metadata:
   name: kafka-connect-cluster
   annotations:
     strimzi.io/use-connector-resources: "true"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   spec:
     logging:

--- a/applications/apicurio-registry/client-application/cdc/kafka/kafka-cluster.yaml
+++ b/applications/apicurio-registry/client-application/cdc/kafka/kafka-cluster.yaml
@@ -1,6 +1,8 @@
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaNodePool
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: controller
   labels:
     strimzi.io/cluster: kafka-cluster
@@ -18,6 +20,8 @@ spec:
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaNodePool
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: broker
   labels:
     strimzi.io/cluster: kafka-cluster
@@ -39,6 +43,7 @@ metadata:
   annotations:
     strimzi.io/node-pools: enabled
     strimzi.io/kraft: enabled
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   kafka:
     version: 3.8.0

--- a/applications/apicurio-registry/client-application/cdc/kafka/strimzi.yaml
+++ b/applications/apicurio-registry/client-application/cdc/kafka/strimzi.yaml
@@ -1,6 +1,8 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
   name: strimzi
 spec:
   targetNamespaces:
@@ -9,6 +11,8 @@ spec:
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
   name: strimzi-kafka-operator
 spec:
   channel: stable

--- a/applications/apicurio-registry/client-application/cdc/kafka/strimzi.yaml
+++ b/applications/apicurio-registry/client-application/cdc/kafka/strimzi.yaml
@@ -4,7 +4,7 @@ metadata:
   name: strimzi
 spec:
   targetNamespaces:
-    - rhaf-apicurio
+    - apicurio
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription

--- a/applications/apicurio-registry/probe-application/probe-application-external-secrets.yaml
+++ b/applications/apicurio-registry/probe-application/probe-application-external-secrets.yaml
@@ -7,35 +7,35 @@ spec:
     name: probe-application-credentials
   secretStoreRef:
     kind: ClusterSecretStore
-    name: vault-mas
+    name: vault-apicurio
   refreshInterval: 1m0s
   data:
     - secretKey: client-id
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/apicurio-probe-application
+        key: kubernetes/dev-eng-apicurio/apicurio/apicurio-probe-application
         property: client-id
     - secretKey: client-secret
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/apicurio-probe-application
+        key: kubernetes/dev-eng-apicurio/apicurio/apicurio-probe-application
         property: client-secret
 
     - secretKey: database
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-registry-client-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-registry-client-credentials
         property: database
     - secretKey: host
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-registry-client-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-registry-client-credentials
         property: host
     - secretKey: port
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-registry-client-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-registry-client-credentials
         property: port
     - secretKey: user
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-registry-client-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-registry-client-credentials
         property: user
     - secretKey: password
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-registry-client-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-registry-client-credentials
         property: password

--- a/applications/apicurio-registry/rds-external-secrets.yaml
+++ b/applications/apicurio-registry/rds-external-secrets.yaml
@@ -7,26 +7,26 @@ spec:
     name: rds-apicurio-registry-credentials
   secretStoreRef:
     kind: ClusterSecretStore
-    name: vault-mas
+    name: vault-apicurio
   refreshInterval: 1m0s
   data:
     - secretKey: database
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-registry-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-registry-credentials
         property: database
     - secretKey: host
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-registry-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-registry-credentials
         property: host
     - secretKey: port
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-registry-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-registry-credentials
         property: port
     - secretKey: user
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-registry-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-registry-credentials
         property: user
     - secretKey: password
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-registry-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-registry-credentials
         property: password

--- a/applications/apicurio-studio/rds-external-secrets.yaml
+++ b/applications/apicurio-studio/rds-external-secrets.yaml
@@ -7,26 +7,26 @@ spec:
     name: rds-apicurio-studio-credentials
   secretStoreRef:
     kind: ClusterSecretStore
-    name: vault-mas
+    name: vault-apicurio
   refreshInterval: 1m0s
   data:
     - secretKey: database
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-studio-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-studio-credentials
         property: database
     - secretKey: host
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-studio-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-studio-credentials
         property: host
     - secretKey: port
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-studio-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-studio-credentials
         property: port
     - secretKey: user
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-studio-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-studio-credentials
         property: user
     - secretKey: password
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-apicurio-studio-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-apicurio-studio-credentials
         property: password

--- a/applications/backstage/rds-external-secrets.yaml
+++ b/applications/backstage/rds-external-secrets.yaml
@@ -7,26 +7,26 @@ spec:
     name: rds-backstage-credentials
   secretStoreRef:
     kind: ClusterSecretStore
-    name: vault-mas
+    name: vault-apicurio
   refreshInterval: 1m0s
   data:
     - secretKey: database
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-backstage-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-backstage-credentials
         property: database
     - secretKey: host
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-backstage-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-backstage-credentials
         property: host
     - secretKey: port
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-backstage-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-backstage-credentials
         property: port
     - secretKey: user
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-backstage-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-backstage-credentials
         property: user
     - secretKey: password
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-backstage-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-backstage-credentials
         property: password

--- a/applications/keycloak/keycloak-external-secrets.yaml
+++ b/applications/keycloak/keycloak-external-secrets.yaml
@@ -7,14 +7,14 @@ spec:
     name: keycloak-credentials
   secretStoreRef:
     kind: ClusterSecretStore
-    name: vault-mas  
+    name: vault-apicurio
   refreshInterval: 1m0s
   data:
     - secretKey: username
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/keycloak-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/keycloak-credentials
         property: username
     - secretKey: password
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/keycloak-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/keycloak-credentials
         property: password

--- a/applications/keycloak/rds-external-secrets.yaml
+++ b/applications/keycloak/rds-external-secrets.yaml
@@ -7,26 +7,26 @@ spec:
     name: rds-keycloak-credentials
   secretStoreRef:
     kind: ClusterSecretStore
-    name: vault-mas  
+    name: vault-apicurio
   refreshInterval: 1m0s
   data:
     - secretKey: database
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-keycloak-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-keycloak-credentials
         property: database
     - secretKey: host
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-keycloak-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-keycloak-credentials
         property: host
     - secretKey: port
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-keycloak-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-keycloak-credentials
         property: port
     - secretKey: user
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-keycloak-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-keycloak-credentials
         property: user
     - secretKey: password
       remoteRef:
-        key: kubernetes/dev-eng-mas/rhaf-apicurio/dev-eng-mas-apicurio-rds-pgsql-keycloak-credentials
+        key: kubernetes/dev-eng-apicurio/apicurio/dev-eng-apicurio-rds-pgsql-keycloak-credentials
         property: password


### PR DESCRIPTION
OCP dev cluster `dev-eng-ocp4-mas` has been renamed in order to remove the suffx `mas`, now the cluster is called just `dev-eng-hcp-apicurio` (the `hcp` string means it is a hosted control plane cluster created with hypershift, so there is no EC2 instance for the master instance, master instance run in a pod).

The namepace has also been renamed, now called `apicurio` (not `rhaf-apicurio`).

The whole rename of the cluster and namespace, implied to rename several things:
- RDS postgres renamed
- Openshift groups renamed
- Vault instance (now deployed with storage on AWS dynamodb with encrypted kms key...). Before it was stored on a file inside a cluster PVV, if cluster is destroyed, PVC is destroyed. Now Vault backend storage can live despite recreating the cluster (in case we need s future migration)
- Vault paths
- OCP console, Vault, ArgoCD URLs
- ....

I fixed a few links which were already broken.

I also fixed the `apicurio-registry` ArgoCD application, which was failing to create anything because it says kakfa CRDs were not present in the cluster, as ArgoCD always do a dry-run to check that all resources that need to be created can actually be created (on that case by first installing the operator):
- Adding  ArgoCD negative sync-wave to strimzi `OperatorGroup` and `Subscription` - so they are applied before anything else  https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/#how-do-i-configure-waves
- Adding ArgoCD `SkipDryRunOnMissingResource=true` sync-option to strimzi CRs - otherwise ArgoCD do a dryrun and Sync fails because CRDs are yet not present https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#skip-dry-run-for-new-custom-resources-types

Right now Argo is using the repo/branch  https://github.com/slopezz/apicurio-3scale-gitops/tree/feat/cluster-rename

There are things that still dont work, so dont merge the PR until everything is working.
- Once everything is working, we will update the `dev.apicur.io` DNS to point the new cluster